### PR TITLE
chore(deps): bump wazero from 1.2.1 to 1.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/testcontainers/testcontainers-go v0.28.0
 	github.com/testcontainers/testcontainers-go/modules/localstack v0.26.0
-	github.com/tetratelabs/wazero v1.2.1
+	github.com/tetratelabs/wazero v1.6.0
 	github.com/twitchtv/twirp v8.1.2+incompatible
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/xlab/treeprint v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1629,8 +1629,8 @@ github.com/testcontainers/testcontainers-go v0.23.0 h1:ERYTSikX01QczBLPZpqsETTBO
 github.com/testcontainers/testcontainers-go v0.23.0/go.mod h1:3gzuZfb7T9qfcH2pHpV4RLlWrPjeWNQah6XlYQ32c4I=
 github.com/testcontainers/testcontainers-go/modules/localstack v0.26.0 h1:lpL04dHA9mGFBQLFcV+aEEh1Tf4ohXdIGgoj3J0bacM=
 github.com/testcontainers/testcontainers-go/modules/localstack v0.26.0/go.mod h1:1xkZPpkBu6coI7CyVn3DXUBnsVrZ+fd/Cc8lx6zk2mk=
-github.com/tetratelabs/wazero v1.2.1 h1:J4X2hrGzJvt+wqltuvcSjHQ7ujQxA9gb6PeMs4qlUWs=
-github.com/tetratelabs/wazero v1.2.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.6.0 h1:z0H1iikCdP8t+q341xqepY4EWvHEw8Es7tlqiVzlP3g=
+github.com/tetratelabs/wazero v1.6.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/twitchtv/twirp v8.1.2+incompatible h1:0O6TfzZW09ZP5r+ORA90XQEE3PTgA6C7MBbl2KxvVgE=

--- a/pkg/module/memfs_test.go
+++ b/pkg/module/memfs_test.go
@@ -1,7 +1,9 @@
 package module
 
 import (
+	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"strings"
 	"testing"
@@ -29,5 +31,29 @@ func TestMemFS(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		_, err = m.Open(path + "tmp")
 		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+}
+
+func TestMemFS_NilIsDirectory(t *testing.T) {
+	// Wasm module initializes before an FS has been
+	// associated to this memFS. We handle nil
+	// so that the guest knows that the mount will map
+	// to a directory in the future.
+	m := &memFS{}
+	require.Nil(t, m.current)
+
+	f, err := m.Open(".")
+	require.NoError(t, err)
+
+	t.Run("stat is dir", func(t *testing.T) {
+		st, err := f.Stat()
+		require.NoError(t, err)
+		require.True(t, st.IsDir())
+	})
+
+	t.Run("read invalid", func(t *testing.T) {
+		buf := make([]byte, 4)
+		_, err = f.Read(buf)
+		require.True(t, errors.Is(err, fs.ErrInvalid))
 	})
 }


### PR DESCRIPTION
This draft updates [wazero](https://wazero.io/) to `main`, and flips the switch to the new advanced optimizing compiler that will be the default in v2.0.0.

Notably, this release introduces new features, such as experimental support to thread spec, and a new compilation pipeline that guarantees increased run-time performance for most workloads: in our tests, this amounts to at least a -30% run-time.

## Description

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
